### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -3,6 +3,8 @@
 # https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-go
 
 name: Go
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/pinkhop/massv2-go/security/code-scanning/6](https://github.com/pinkhop/massv2-go/security/code-scanning/6)

The best way to address this issue is to add a `permissions` block at the top level of the workflow file, directly after the `name:` and before the `on:` section. This will apply the minimal required permissions (`contents: read`) to all jobs, unless specifically overridden. Since the workflow only builds, vets, tests, and builds the project—all read-only operations—it is safe and correct to specify `contents: read` globally. No other jobs require more permissions. 

To implement, insert the following block:
```yaml
permissions:
  contents: read
```
immediately below the line with `name: Go` (i.e., after line 5).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
